### PR TITLE
[akffkdahffkdgo77] Listbox 컴포넌트 리팩토링

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -36,6 +36,7 @@ module.exports = {
                 ignore: ['css']
             }
         ],
+        'react/no-array-index-key': 'off',
         'react/react-in-jsx-scope': 'off',
         'import/no-extraneous-dependencies': 'off',
         'react/function-component-definition': 'off',

--- a/src/components/Base/Backdrop/Backdrop.tsx
+++ b/src/components/Base/Backdrop/Backdrop.tsx
@@ -19,15 +19,29 @@ const FOCUSABLE = 'button, a, input, select, textarea, [tabindex]:not([tabindex=
  *  [Base Component] Backdrop(Overlay) Component
  *  @param children 컴포넌트
  *  @param onClose Click Away Handler
- *  @param backgroundColor [CSS] 배경 색상
+ *  @param isOpen 노출 여부 [optional]
  *  @param isDimmed 배경 색상 설정 여부 [optional]
- *  @param containerId DOM id [optional]
+ *  @param backgroundColor [CSS] 배경 색상
  *  @returns JSX.Element
  */
 export default function Backdrop(props: BackdropType) {
     const { children, isOpen, isDimmed = false, backgroundColor, onClose } = props;
     const portalRef = useRef<HTMLDivElement>(null);
 
+    useEffect(() => {
+        if (isOpen) {
+            document.body.style.overflow = 'hidden';
+        } else {
+            document.body.style.removeProperty('overflow');
+        }
+
+        return () => {
+            document.body.style.removeProperty('overflow');
+        };
+    }, [isOpen]);
+
+    // shift + tab -> backward
+    // tab -> forward
     const handleKeyPress = useCallback((e: KeyboardEvent) => {
         const focusable = portalRef.current?.querySelectorAll(FOCUSABLE) || [];
         const firstElement = [...focusable].shift() as HTMLElement;
@@ -51,8 +65,6 @@ export default function Backdrop(props: BackdropType) {
 
     useEffect(() => {
         if (isOpen) {
-            // shift + tab -> backward
-            // tab -> forward
             document.addEventListener('keydown', handleKeyPress);
         }
         return () => document.removeEventListener('keydown', handleKeyPress);

--- a/src/components/Base/Box/Box.tsx
+++ b/src/components/Base/Box/Box.tsx
@@ -1,0 +1,21 @@
+/** @jsxImportSource @emotion/react */
+import { ReactNode } from 'react';
+
+import { css } from '@emotion/react';
+import type { CustomCSSType } from 'styles/types';
+
+type BoxType = CustomCSSType & {
+    children: ReactNode;
+};
+
+/**
+ *  Styled Div Component
+ *  @param children ReactNode
+ *  @param customCSS 커스텀 css [optional]
+ *  @returns JSX.Element
+ */
+const Box = ({ children, customCSS }: BoxType) => {
+    return <div css={css(customCSS)}>{children}</div>;
+};
+
+export default Box;

--- a/src/components/Base/Box/index.ts
+++ b/src/components/Base/Box/index.ts
@@ -1,0 +1,3 @@
+import Box from './Box';
+
+export default Box;

--- a/src/components/Base/index.ts
+++ b/src/components/Base/index.ts
@@ -1,4 +1,5 @@
 export { default as Backdrop } from './Backdrop';
+export { default as Box } from './Box';
 export { default as ClickAwayListener } from './ClickAwayListener';
 export { default as FlexBox } from './FlexBox';
 export { default as FormControl } from './FormControl';

--- a/src/components/Button/Button/Button.tsx
+++ b/src/components/Button/Button/Button.tsx
@@ -71,7 +71,7 @@ export default function Button(props: ButtonType) {
                     {hasEndIcon && <span css={buttonStyle.endIcon}>{icon}</span>}
                 </FlexBox>
             ) : (
-                <div>{children}</div>
+                children
             )}
         </button>
     );

--- a/src/components/Combobox/Select/styles.ts
+++ b/src/components/Combobox/Select/styles.ts
@@ -54,5 +54,9 @@ export const selectStyle = {
             width: 20,
             height: 20
         }
+    }),
+    listContainer: css({
+        position: 'fixed',
+        width: '100%'
     })
 };

--- a/src/components/Combobox/usePosition.ts
+++ b/src/components/Combobox/usePosition.ts
@@ -1,0 +1,68 @@
+import { useCallback, useEffect, useState } from 'react';
+
+interface Props {
+    isVisible: boolean;
+    inputId: string;
+    listBoxId: string;
+    totalLength: number;
+}
+
+const MAX_MENU_HEIGHT = 300;
+const AVG_OPTION_HEIGHT = 24;
+const MIN_OFFSET = 20;
+
+const usePosition = ({ isVisible, inputId, listBoxId, totalLength }: Props) => {
+    const [top, setTop] = useState(0);
+    const [left, setLeft] = useState(0);
+    const [marginTop, setMarginTop] = useState(1);
+    const [maxWidth, setMaxWidth] = useState(300);
+
+    // listbox가 페이지 범위를 넘어가는지 확인하는 함수
+    // MIN_OFFSET : 메뉴가 페이지 하단에 너무 가깝지 않도록
+    const isTop = useCallback(() => {
+        const element = document.getElementById(inputId);
+        if (element) {
+            return (
+                element.getBoundingClientRect().bottom +
+                    Math.min(MAX_MENU_HEIGHT, totalLength * AVG_OPTION_HEIGHT) +
+                    MIN_OFFSET >=
+                window.innerHeight
+            );
+        }
+
+        return false;
+    }, [totalLength]);
+
+    const handlePosition = useCallback(() => {
+        const element = document.getElementById(inputId);
+        const list = document.getElementById(listBoxId);
+
+        if (isVisible && element && list) {
+            const defaultTop = element.getBoundingClientRect().top;
+            if (isTop()) {
+                setTop(defaultTop - list.offsetHeight + 1);
+                setMarginTop(1);
+            } else {
+                setTop(1);
+                setMarginTop(element.getBoundingClientRect().top + element.getBoundingClientRect().height - 1);
+            }
+            setLeft(element.getBoundingClientRect().x);
+            setMaxWidth(element.getBoundingClientRect().width);
+        }
+    }, [isVisible]);
+
+    useEffect(() => {
+        handlePosition();
+        window.addEventListener('resize', handlePosition);
+        window.addEventListener('scroll', handlePosition);
+
+        return () => {
+            window.removeEventListener('resize', handlePosition);
+            window.removeEventListener('scroll', handlePosition);
+        };
+    }, [handlePosition]);
+
+    return { handlePosition, isTop, top, left, marginTop, maxWidth };
+};
+
+export default usePosition;

--- a/src/components/Listbox/Listbox.tsx
+++ b/src/components/Listbox/Listbox.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource @emotion/react */
-import { MouseEvent, ReactNode, forwardRef } from 'react';
+import { HTMLAttributes, MouseEvent, ReactNode, forwardRef } from 'react';
 
 import { css } from '@emotion/react';
 import { CustomCSSType } from 'styles';
@@ -9,9 +9,11 @@ import { listBoxStyle } from './styles';
 
 export type OptionType = { [key: string]: string | number };
 
-type ListboxType = CustomCSSType & {
+type BaseType = Omit<HTMLAttributes<HTMLUListElement>, 'onClick'> & CustomCSSType;
+
+type ListboxType = BaseType & {
     id: string;
-    labelId: string;
+    labelId?: string;
     name: string;
     value: string | number;
     options: OptionType[];
@@ -21,21 +23,22 @@ type ListboxType = CustomCSSType & {
 
 /**
  *  Listbox Component
- *  @param id
- *  @param labelId
- *  @param name
- *  @param value
- *  @param options
- *  @param onClick
- *  @param renderItem
+ *  @param id Listbox Id
+ *  @param name Autocomplete Name
+ *  @param value Selected value
+ *  @param options Option List
+ *  @param labelId Label Id [optional]
+ *  @param onClick Click Event Handler for list option [optional]
+ *  @param renderItem Custom Listbox Item Component [optional]
  *  @returns JSX.Element
  */
 const Listbox = forwardRef<HTMLUListElement, ListboxType>(function createListbox(
-    { id, labelId, value, options, renderItem, customCSS, ...props },
+    { id, labelId, value, options, renderItem, customCSS, name, onClick, ...props },
     ref
 ) {
     return (
         <ul
+            {...props}
             ref={ref}
             id={id}
             role="listbox"
@@ -48,10 +51,11 @@ const Listbox = forwardRef<HTMLUListElement, ListboxType>(function createListbox
                     renderItem?.(option) || (
                         <ListboxItem
                             key={`${option.label}-${option.value}`}
+                            name={name}
                             currentValue={value}
                             label={option.label}
                             value={option.value}
-                            {...props}
+                            onClick={onClick}
                         />
                     )
             )}

--- a/src/components/Listbox/Listbox.tsx
+++ b/src/components/Listbox/Listbox.tsx
@@ -1,52 +1,62 @@
 /** @jsxImportSource @emotion/react */
-import { MouseEvent } from 'react';
+import { MouseEvent, ReactNode, forwardRef } from 'react';
 
 import { css } from '@emotion/react';
-import { palette } from 'styles';
+import { CustomCSSType } from 'styles';
 
-import Button from 'components/Button/Button';
-
+import ListboxItem from './ListboxItem';
 import { listBoxStyle } from './styles';
 
-export type OptionType = { label: string; value: string | number };
+export type OptionType = { [key: string]: string | number };
 
-type ListboxType = {
+type ListboxType = CustomCSSType & {
     id: string;
     labelId: string;
     name: string;
     value: string | number;
     options: OptionType[];
-    onClick: (e: MouseEvent<HTMLButtonElement>) => void;
+    onClick?: (e: MouseEvent<HTMLButtonElement>) => void;
+    renderItem?: (option: OptionType) => ReactNode;
 };
 
-const Listbox = ({ id, labelId, name, value, options, onClick }: ListboxType) => (
-    <ul id={id} role="listbox" aria-labelledby={labelId} tabIndex={-1} css={listBoxStyle.list}>
-        {options.map((option) => (
-            <li
-                key={option.value}
-                role="option"
-                aria-selected={value === option.value}
-                css={css([
-                    listBoxStyle.listItem,
-                    {
-                        ...(value === option.value && {
-                            '&, & button': {
-                                textAlign: 'left',
-                                width: '100%',
-                                fontWeight: 600,
-                                color: palette.neutral.white,
-                                backgroundColor: palette.primary[400]
-                            }
-                        })
-                    }
-                ])}
-            >
-                <Button type="button" name={name} value={option.value} onClick={onClick}>
-                    {option.label}
-                </Button>
-            </li>
-        ))}
-    </ul>
-);
+/**
+ *  Listbox Component
+ *  @param id
+ *  @param labelId
+ *  @param name
+ *  @param value
+ *  @param options
+ *  @param onClick
+ *  @param renderItem
+ *  @returns JSX.Element
+ */
+const Listbox = forwardRef<HTMLUListElement, ListboxType>(function createListbox(
+    { id, labelId, value, options, renderItem, customCSS, ...props },
+    ref
+) {
+    return (
+        <ul
+            ref={ref}
+            id={id}
+            role="listbox"
+            aria-labelledby={labelId}
+            tabIndex={-1}
+            css={css([listBoxStyle.list, customCSS])}
+        >
+            {options.map(
+                (option) =>
+                    renderItem?.(option) || (
+                        <ListboxItem
+                            key={`${option.label}-${option.value}`}
+                            currentValue={value}
+                            label={option.label}
+                            value={option.value}
+                            {...props}
+                        />
+                    )
+            )}
+        </ul>
+    );
+});
 
 export default Listbox;

--- a/src/components/Listbox/ListboxItem.tsx
+++ b/src/components/Listbox/ListboxItem.tsx
@@ -1,0 +1,46 @@
+/** @jsxImportSource @emotion/react */
+import { MouseEvent, ReactNode } from 'react';
+
+import { css } from '@emotion/react';
+
+import Button from 'components/Button/Button';
+
+import { listBoxStyle } from './styles';
+
+type ListboxItemType = {
+    currentValue: string | number;
+    name: string;
+    label: string | ReactNode;
+    value: string | number;
+    onClick?: (e: MouseEvent<HTMLButtonElement>) => void;
+};
+
+/**
+ *  Listbox Item Component
+ *  @param currentValue
+ *  @param name
+ *  @param label
+ *  @param value
+ *  @param onClick
+ *  @returns JSX.Element
+ */
+const ListboxItem = ({ currentValue, name, label, value, onClick }: ListboxItemType) => {
+    return (
+        <li
+            role="option"
+            aria-selected={currentValue === value}
+            css={css([
+                listBoxStyle.listItem,
+                {
+                    ...(currentValue === value && listBoxStyle.selectedListItem)
+                }
+            ])}
+        >
+            <Button type="button" name={name} value={value} onClick={onClick}>
+                {label}
+            </Button>
+        </li>
+    );
+};
+
+export default ListboxItem;

--- a/src/components/Listbox/index.ts
+++ b/src/components/Listbox/index.ts
@@ -1,5 +1,4 @@
-import Listbox from './Listbox';
-
-export default Listbox;
+export { default as Listbox } from './Listbox';
+export { default as ListboxItem } from './ListboxItem';
 
 export * from './Listbox';

--- a/src/components/Listbox/styles.ts
+++ b/src/components/Listbox/styles.ts
@@ -5,7 +5,7 @@ export const listBoxStyle = {
     list: css({
         width: '100%',
         maxHeight: 300,
-        padding: '10px 0',
+        padding: '4px 0',
         border: `1px solid ${palette.gray[100]}`,
         borderRadius: 4,
         backgroundColor: palette.neutral.white,
@@ -35,6 +35,9 @@ export const listBoxStyle = {
         '& button:focus': {
             fontWeight: 900,
             color: palette.primary[900]
+        },
+        '&:last-of-type': {
+            borderBottom: 0
         }
     }),
     selectedListItem: css({
@@ -43,7 +46,10 @@ export const listBoxStyle = {
             width: '100%',
             fontWeight: 600,
             color: palette.neutral.white,
-            backgroundColor: palette.primary[400]
+            backgroundColor: palette.primary[400],
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+            overflow: 'hidden'
         }
     })
 };

--- a/src/components/Listbox/styles.ts
+++ b/src/components/Listbox/styles.ts
@@ -36,5 +36,14 @@ export const listBoxStyle = {
             fontWeight: 900,
             color: palette.primary[900]
         }
+    }),
+    selectedListItem: css({
+        '&, & button': {
+            textAlign: 'left',
+            width: '100%',
+            fontWeight: 600,
+            color: palette.neutral.white,
+            backgroundColor: palette.primary[400]
+        }
     })
 };

--- a/src/components/Shared/Autocomplete/Autocomplete.tsx
+++ b/src/components/Shared/Autocomplete/Autocomplete.tsx
@@ -1,0 +1,160 @@
+/** @jsxImportSource @emotion/react */
+import { useRef, useState, useId, ChangeEvent } from 'react';
+
+import { CustomCSSType } from 'styles';
+import palette from 'styles/palette';
+
+import { Backdrop, Typography } from 'components/Base';
+import Box from 'components/Base/Box';
+import FlexBox from 'components/Base/FlexBox';
+import usePosition from 'components/Combobox/usePosition';
+import TextField from 'components/Form/TextField';
+import { Listbox, OptionType, ListboxItem } from 'components/Listbox';
+
+import { autoCompleteStyle } from './styles';
+
+type AutocompleteType = CustomCSSType & {
+    name: string;
+    options: OptionType[];
+    inputValue: string;
+    onChange: (newValue: string | number) => void;
+    onSelect: (newOption?: OptionType) => void;
+    labelText?: string;
+    helperText?: string;
+};
+
+/**
+ *  [UI Component] Autocomplete Component
+ *  @param name Autocomplete Name
+ *  @param options Option List
+ *  @param inputValue TextField value
+ *  @param onChange TextField Change Event Handler
+ *  @param onSelect Select Change Event Handler
+ *  @param labelText Label Text [optional]
+ *  @param helperText Helper Text [optional]
+ *  @returns JSX.Element
+ */
+export default function Autocomplete(props: AutocompleteType) {
+    const { labelText, helperText, options, name, inputValue, onChange, onSelect, customCSS } = props;
+
+    const inputRef = useRef<HTMLInputElement | null>(null);
+
+    const [isVisible, setIsVisible] = useState<boolean>(false);
+    const [selected, setSelected] = useState<OptionType>();
+
+    const labelId = useId();
+    const listBoxId = useId();
+    const inputId = useId();
+
+    const { top, left, marginTop, maxWidth } = usePosition({
+        inputId,
+        listBoxId,
+        isVisible,
+        totalLength: options.length
+    });
+
+    const handleSelect = (newOption: OptionType) => {
+        setSelected(newOption);
+        onSelect(newOption);
+        onChange(newOption.label);
+    };
+
+    const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+        onChange(e.currentTarget.value);
+        if (!e.currentTarget.value) {
+            setSelected(undefined);
+            onSelect();
+        }
+    };
+
+    const handleClick = () => {
+        // 옵션 선택 후 list 미노출
+        if (selected && isVisible) {
+            setIsVisible(false);
+        } else {
+            setIsVisible((prev) => !prev);
+        }
+    };
+
+    return (
+        <Box customCSS={customCSS}>
+            <FlexBox alignItems="center" justifyContent="center" gap={5} customCSS={autoCompleteStyle.inputContainer}>
+                <TextField
+                    ref={inputRef}
+                    aria-label={!labelText ? `${name}` : undefined}
+                    id={inputId}
+                    labelText={labelText}
+                    helperText={helperText}
+                    type="text"
+                    role="combobox"
+                    aria-autocomplete="list"
+                    aria-expanded={isVisible}
+                    aria-controls={listBoxId}
+                    value={inputValue}
+                    onChange={handleChange}
+                    onClick={handleClick}
+                />
+            </FlexBox>
+            {isVisible && (
+                <Backdrop isOpen={isVisible} onClose={handleClick}>
+                    <Box
+                        customCSS={{
+                            ...autoCompleteStyle.listContainer,
+                            ...{
+                                top,
+                                left,
+                                marginTop,
+                                '& > ul': {
+                                    maxWidth
+                                }
+                            }
+                        }}
+                    >
+                        <Listbox
+                            id={listBoxId}
+                            labelId={labelText ? labelId : undefined}
+                            aria-label={labelText ? undefined : `${name}`}
+                            name={name}
+                            value={selected?.value || ''}
+                            options={options}
+                            renderItem={(option) => (
+                                <ListboxItem
+                                    key={option.label}
+                                    currentValue={selected?.value || ''}
+                                    name={name}
+                                    label={
+                                        inputValue
+                                            ? (option.label as string)
+                                                  .split(new RegExp(`(${inputValue})`, 'gi'))
+                                                  .filter((val) => val)
+                                                  .map((letter, idx) => (
+                                                      <Typography
+                                                          key={letter + idx}
+                                                          component="span"
+                                                          color={
+                                                              new RegExp(`(${inputValue})`, 'gi').test(letter)
+                                                                  ? palette.primary[600]
+                                                                  : palette.neutral.black
+                                                          }
+                                                          fontWeight={
+                                                              new RegExp(`(${inputValue})`, 'gi').test(letter)
+                                                                  ? '700'
+                                                                  : '400'
+                                                          }
+                                                      >
+                                                          {letter}
+                                                      </Typography>
+                                                  ))
+                                            : option.label
+                                    }
+                                    value={option.value}
+                                    onClick={() => handleSelect(option)}
+                                />
+                            )}
+                        />
+                    </Box>
+                </Backdrop>
+            )}
+        </Box>
+    );
+}

--- a/src/components/Shared/Autocomplete/index.ts
+++ b/src/components/Shared/Autocomplete/index.ts
@@ -1,0 +1,3 @@
+import Autocomplete from './Autocomplete';
+
+export default Autocomplete;

--- a/src/components/Shared/Autocomplete/styles.ts
+++ b/src/components/Shared/Autocomplete/styles.ts
@@ -1,0 +1,12 @@
+import { palette } from 'styles';
+
+export const autoCompleteStyle = {
+    inputContainer: {
+        width: '100%',
+        backgroundColor: palette.neutral.white
+    },
+    listContainer: {
+        position: 'fixed' as const,
+        width: '100%'
+    }
+};

--- a/src/pages/Home/examples/AutoCompleteExample.tsx
+++ b/src/pages/Home/examples/AutoCompleteExample.tsx
@@ -1,29 +1,35 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, ChangeEvent } from 'react';
 
 import _ from 'lodash';
 
-import FlexBox from 'components/Base/FlexBox';
-import Typography from 'components/Base/Typography';
-import AutoComplete from 'components/Combobox/Autocomplete';
+import { Box, FlexBox, Typography } from 'components/Base';
+import Autocomplete from 'components/Combobox/Autocomplete';
+import SharedAutoComplete from 'components/Shared/Autocomplete';
 
-import { AUTOCOMPLETE as LIST } from './constants';
+import { AUTOCOMPLETE as LIST, AutocompleteType } from './constants';
 
-type ListType = {
-    idx: number;
-    label: string;
-    value: string;
+const autoCompleteStyle = {
+    container: {
+        margin: '20px 0'
+    },
+    text: {
+        width: '100%',
+        display: 'block',
+        textOverflow: 'ellipsis',
+        whiteSpace: 'nowrap' as const,
+        overflow: 'hidden'
+    }
 };
 
 export default function AutoCompleteExample() {
-    const [listArr, setListArr] = useState<ListType[]>(LIST);
+    const [listArr, setListArr] = useState<AutocompleteType[]>(LIST);
     const [inputValue, setInputValue] = useState<string>('');
-    const [selectedItem, setSelectedItem] = useState<ListType>();
+    const [selectedItem, setSelectedItem] = useState<AutocompleteType>();
 
     const handleSearch = useCallback(
         _.debounce((value: string) => {
-            let newArr = [];
             if (value.length !== 0 && value !== '') {
-                newArr = LIST.filter((el: ListType) => el.label.includes(value));
+                const newArr = LIST.filter((el) => value.includes(el.label as string));
                 setListArr(newArr);
             } else {
                 setListArr(LIST);
@@ -32,22 +38,50 @@ export default function AutoCompleteExample() {
         []
     );
 
-    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-        const { value } = e.target;
+    const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+        const { value } = e.currentTarget;
         setInputValue(value);
         handleSearch(value);
     };
 
+    const handleShareChange = (newValue: string | number) => {
+        setInputValue(String(newValue));
+        handleSearch(String(newValue));
+    };
+
     return (
-        <FlexBox flexDirection="column" gap={10} customCSS={{ margin: '20px 0' }}>
-            <Typography component="span">선택된 항목의 LABEL: {selectedItem?.label}</Typography>
-            <AutoComplete
-                label="autoComplete"
-                listArr={listArr}
-                inputValue={inputValue}
-                onChange={handleChange}
-                onSelect={(e) => setSelectedItem(e)}
-            />
+        <FlexBox flexDirection="column" gap={10} customCSS={autoCompleteStyle.container}>
+            <Box>
+                <Typography>
+                    선택된 항목 :{' '}
+                    <Typography component="strong" customCSS={autoCompleteStyle.text}>
+                        {selectedItem?.label}
+                    </Typography>
+                </Typography>
+                <Autocomplete
+                    label="states"
+                    listArr={listArr}
+                    inputValue={inputValue}
+                    onChange={handleChange}
+                    onSelect={(e) => setSelectedItem(e as AutocompleteType)}
+                />
+            </Box>
+            <Box>
+                <Typography>
+                    선택된 항목 :{' '}
+                    <Typography component="strong" customCSS={autoCompleteStyle.text}>
+                        {selectedItem?.label}
+                    </Typography>
+                </Typography>
+                <SharedAutoComplete
+                    labelText="Lorem Ipsum"
+                    name="lorem ipsum"
+                    options={listArr}
+                    inputValue={inputValue}
+                    onChange={handleShareChange}
+                    onSelect={(e) => setSelectedItem(e as AutocompleteType)}
+                />
+            </Box>
         </FlexBox>
     );
 }

--- a/src/pages/Home/examples/constants.ts
+++ b/src/pages/Home/examples/constants.ts
@@ -6,59 +6,37 @@ export const OPTIONS = [
     { label: '우유', value: '4' }
 ];
 
+export type AutocompleteType = {
+    idx: number;
+    label: string;
+    value: string;
+};
+
 export const AUTOCOMPLETE = [
     {
         idx: 1,
-        label: 'first option',
-        value: 'hello01'
+        label: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+        value: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.'
     },
     {
         idx: 2,
-        label: 'second option',
-        value: 'hello02'
+        label: 'Sed in eros vitae erat sollicitudin sagittis sed tincidunt odio. ',
+        value: 'Sed in eros vitae erat sollicitudin sagittis sed tincidunt odio. '
     },
     {
         idx: 3,
-        label: 'third option',
-        value: 'hello03'
+        label: 'Donec libero enim, placerat vitae tempus ac, luctus sed ex. Ut fringilla vestibulum molestie.',
+        value: 'Donec libero enim, placerat vitae tempus ac, luctus sed ex. Ut fringilla vestibulum molestie.'
     },
     {
         idx: 4,
-        label: 'fourth option',
-        value: 'hello04'
+        label: 'Ut lacinia posuere imperdiet.',
+        value: 'Ut lacinia posuere imperdiet.'
     },
     {
         idx: 5,
-        label: 'fifth option',
-        value: 'hello05'
-    }
-];
-
-export const COMBOBOX = [
-    {
-        idx: 1,
-        label: 'sample_01',
-        value: 'sample01'
-    },
-    {
-        idx: 2,
-        label: 'sample_02',
-        value: 'sample02'
-    },
-    {
-        idx: 3,
-        label: 'sample_03',
-        value: 'sample03'
-    },
-    {
-        idx: 4,
-        label: 'sample_04',
-        value: 'sample04'
-    },
-    {
-        idx: 5,
-        label: 'sample_05',
-        value: 'sample05'
+        label: 'Curabitur non elit quis ante vulputate iaculis.',
+        value: 'Curabitur non elit quis ante vulputate iaculis.'
     }
 ];
 

--- a/src/stories/components/constants.ts
+++ b/src/stories/components/constants.ts
@@ -33,31 +33,3 @@ export const AUTOCOMPLETE = [
         value: 'hello05'
     }
 ];
-
-export const COMBOBOX = [
-    {
-        idx: 1,
-        label: 'sample_01',
-        value: 'sample01'
-    },
-    {
-        idx: 2,
-        label: 'sample_02',
-        value: 'sample02'
-    },
-    {
-        idx: 3,
-        label: 'sample_03',
-        value: 'sample03'
-    },
-    {
-        idx: 4,
-        label: 'sample_04',
-        value: 'sample04'
-    },
-    {
-        idx: 5,
-        label: 'sample_05',
-        value: 'sample05'
-    }
-];


### PR DESCRIPTION
# Listbox 컴포넌트 리팩토링

## 작업한 내용

-   [x] Listbox 컴포넌트 리팩토링
-   [x] `components/Shared`에 Listbox를 사용한 Autocomplete 컴포넌트 추가
-   [x] Listbox 관련된 usePosition 커스텀 훅 추가 (backdrop이 fixed라서 select, autocomplete에서 중복 -> 커스텀 훅으로 분리)
-   [x] Backdrop에 overflow 설정 코드 추가 (select, autocomplete에서 중복되는 코드라서 backdrop에 코드 추가)

## 예시

<img width="1414" alt="스크린샷 2024-01-20 오후 1 01 51" src="https://github.com/UsePlease-UI/react-components/assets/52883505/9805aa0c-f4b3-4b2f-a477-43554ac9be35">


## 기타
-   [x] Box 컴포넌트 추가
